### PR TITLE
switch to recent redbug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ectl -- Erlang Controller
 =================
 
-`ectl` is an escript command-line interface for some useful debugging and profiling tools for erlang VM, [redbug](https://github.com/basho/eper) and [recon](https://github.com/ferd/recon) are currently supported.
+`ectl` is an escript command-line interface for some useful debugging and profiling tools for erlang VM, [redbug](https://github.com/massemanet/redbug) and [recon](https://github.com/ferd/recon) are currently supported.
 
 ```bash
 $ ./ectl
@@ -40,7 +40,7 @@ then you will have an executable `ectl` script in the folder.
 
 ### redbug
 
-[redbug](https://github.com/basho/eper) is similar to the OTP dbg application, but safer, better etc. `ectl` wraps this great tool in a nicer cli interface.
+[redbug](https://github.com/massemanet/redbug) is similar to the OTP dbg application, but safer, better etc. `ectl` wraps this great tool in a nicer cli interface.
 
 ```bash
 $ ./ectl redbug -h

--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,8 @@
 {deps, [
     {ecli, ".*", 
       {git, "https://github.com/stwind/ecli.git", {branch, "develop"}}},
-    {eper, ".*", 
-      {git, "https://github.com/basho/eper.git", {branch, "develop"}}},
+    {redbug, ".*",
+      {git, "https://github.com/massemanet/redbug.git", {branch, "master"}}},
     {recon, ".*", 
       {git, "https://github.com/ferd/recon.git", {branch, "master"}}}
   ]}.
@@ -24,7 +24,7 @@
     "ectl"
   ]}.
 
-{escript_incl_apps, [ecli, getopt, eper, recon]}.
+{escript_incl_apps, [ecli, getopt, redbug, recon]}.
 
 {xref_checks, [undefined_function_calls]}.
 


### PR DESCRIPTION
eper does not build on recent OTP releases and the
original eper source states that redbug development is
continued at https://github.com/massemanet/redbug